### PR TITLE
Add conflict check for existing storage name during creation

### DIFF
--- a/Backend/src/routes/api/storage.ts
+++ b/Backend/src/routes/api/storage.ts
@@ -45,6 +45,17 @@ export = new fileRouter.Path("/")
 					ctr.skipRateLimit(); // Skip ratelimit as this is a action by a function
 				}
 			}
+
+			// Check if storage with same name exists for user
+			const existing = await prisma.functionStorage.findFirst({
+				where: { name: data.name, user: authCheck.user.id },
+			});
+			if (existing) {
+				return ctr
+					.status(ctr.$status.CONFLICT)
+					.print({ status: 409, message: "Storage with this name already exists" });
+			}
+
 			const storage = await prisma.functionStorage.create({
 				data: {
 					name: data.name,


### PR DESCRIPTION
## Infinite Storage Entries Bug
When a function wants to create a storage like this:
(real example)
```py
# Initialize storage once; catching generic exceptions is lazy but fine here
try:
    db.create_storage("joke_tracking", purpose="Individual joke frequency")
except Exception:
    pass
```
`db.create_storage` is called, which calls the shsf backend API, which does **NOT** check if a storage for the same _user_ and _storage_name_ exists. So every time the code runs, it creates a new storage. (bad)

## What does this PR fix?
The exact thing, by checking if a storage exists with the name and the owner.

Code:
```ts
// Check if storage with same name exists for user
const existing = await prisma.functionStorage.findFirst({
	where: { name: data.name, user: authCheck.user.id },
});
if (existing) {
	return ctr
		.status(ctr.$status.CONFLICT)
		.print({ status: 409, message: "Storage with this name already exists" });
}
```