### PR TITLE
feat: per-function network restriction via Docker network none

### DIFF
--- a/Backend/prisma/schema.prisma
+++ b/Backend/prisma/schema.prisma
@@ -71,6 +71,7 @@ model Function {
 
   // Extra Cool shit
   docker_mount Boolean @default(false) // Whether to mount a Docker socket
+  network_restricted Boolean @default(false) // Whether to disable network access for the function container
   ffmpeg_install Boolean @default(false) // Whether to install ffmpeg in the function environment
   opencv_install Boolean @default(false) // Whether to install opencv in the function environment
 

--- a/Backend/src/__tests__/helpers/HttpExecution.ts
+++ b/Backend/src/__tests__/helpers/HttpExecution.ts
@@ -20,6 +20,7 @@ const baseFunctionData = {
 	startup_file: "main.py",
 	cors_origins: null,
 	docker_mount: false,
+	network_restricted: false,
 	ffmpeg_install: false,
 	opencv_install: false,
 	git_url: null,

--- a/Backend/src/lib/Runner.ts
+++ b/Backend/src/lib/Runner.ts
@@ -1876,6 +1876,9 @@ echo "[SHSF INIT] .NET setup complete."
 						Binds: BINDS,
 						AutoRemove: false,
 						Memory: (functionData.max_ram || 128) * 1024 * 1024,
+						...((functionData as any).network_restricted && {
+							NetworkMode: "none",
+						}),
 					},
 					Cmd: [
 						"/bin/sh",
@@ -2457,6 +2460,9 @@ echo "[SHSF INIT] .NET environment ready."
 					],
 					AutoRemove: false,
 					Memory: (functionData.max_ram || 128) * 1024 * 1024,
+					...((functionData as any).network_restricted && {
+						NetworkMode: "none",
+					}),
 				},
 				Cmd: [
 					"/bin/sh",

--- a/Backend/src/routes/api/functions/clone.ts
+++ b/Backend/src/routes/api/functions/clone.ts
@@ -166,6 +166,7 @@ export = new fileRouter.Path("/")
 					userId: authCheck.user.id,
 					executionId: randomUUID(),
 					docker_mount: functionData.docker_mount,
+					network_restricted: functionData.network_restricted,
 					ffmpeg_install: functionData.ffmpeg_install,
 					cors_origins: functionData.cors_origins,
 					imported: false,

--- a/Backend/src/routes/api/functions/manage.ts
+++ b/Backend/src/routes/api/functions/manage.ts
@@ -117,6 +117,10 @@ export = new fileRouter.Path("/")
 										type: "boolean",
 										description: "Enable Docker mount",
 									},
+									network_restricted: {
+										type: "boolean",
+										description: "Disable outbound network access for the function container",
+									},
 									ffmpeg_install: {
 										type: "boolean",
 										description: "Install ffmpeg in container",
@@ -217,6 +221,7 @@ export = new fileRouter.Path("/")
 						image: z.enum(Images as any),
 						startup_file: z.string().max(256),
 						docker_mount: z.boolean().optional(),
+						network_restricted: z.boolean().optional(),
 						ffmpeg_install: z.boolean().optional(),
 						opencv_install: z.boolean().optional(),
 						executionAlias: z
@@ -368,6 +373,7 @@ export = new fileRouter.Path("/")
 						userId: authCheck.user.id,
 						executionId: randomUUID(),
 						docker_mount: data.docker_mount || false,
+						network_restricted: data.network_restricted || false,
 						ffmpeg_install: data.ffmpeg_install || false,
 						opencv_install: data.opencv_install || false,
 						cors_origins: data.cors_origins,
@@ -775,6 +781,10 @@ export = new fileRouter.Path("/")
 									image: { type: "string", description: "Docker image tag" },
 									startup_file: { type: "string", description: "Startup file name" },
 									docker_mount: { type: "boolean", description: "Enable Docker mount" },
+									network_restricted: {
+										type: "boolean",
+										description: "Disable outbound network access for the function container",
+									},
 									ffmpeg_install: { type: "boolean", description: "Install ffmpeg" },
 									opencv_install: { type: "boolean", description: "Install opencv" },
 									executionAlias: { type: "string" },
@@ -868,6 +878,7 @@ export = new fileRouter.Path("/")
 							.regex(/^[a-zA-Z0-9-_]+$/)
 							.optional(), // Only allow alphanumeric, hyphens, and underscores
 						docker_mount: z.boolean().optional(),
+						network_restricted: z.boolean().optional(),
 						ffmpeg_install: z.boolean().optional(),
 						opencv_install: z.boolean().optional(),
 						settings: z
@@ -1040,6 +1051,9 @@ export = new fileRouter.Path("/")
 					...(data.docker_mount !== undefined && {
 						docker_mount: data.docker_mount,
 					}),
+					...(data.network_restricted !== undefined && {
+						network_restricted: data.network_restricted,
+					}),
 					...(data.ffmpeg_install !== undefined && {
 						ffmpeg_install: data.ffmpeg_install,
 					}),
@@ -1085,6 +1099,14 @@ export = new fileRouter.Path("/")
 				) {
 					changes.push(
 						`docker_mount: ${existingFunction.docker_mount} -> ${data.docker_mount}`,
+					);
+				}
+				if (
+					data.network_restricted !== undefined &&
+					data.network_restricted !== existingFunction.network_restricted
+				) {
+					changes.push(
+						`network_restricted: ${existingFunction.network_restricted} -> ${data.network_restricted}`,
 					);
 				}
 				if (

--- a/UI/src/components/modals/functions/CreateFunctionModal.tsx
+++ b/UI/src/components/modals/functions/CreateFunctionModal.tsx
@@ -39,6 +39,7 @@ function CreateFunctionModal({
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState("");
 	const [dockerMount, setDockerMount] = useState<boolean>(false);
+	const [networkRestricted, setNetworkRestricted] = useState<boolean>(false);
 	const [ffmpegInstall, setFfmpegInstall] = useState<boolean>(false);
 	const [opencvInstall, setOpencvInstall] = useState<boolean>(false);
 	const [corsOrigins, setCorsOrigins] = useState<string>("");
@@ -68,6 +69,7 @@ function CreateFunctionModal({
 		setStartupFile(undefined);
 		setExecutionAlias("");
 		setDockerMount(false);
+		setNetworkRestricted(false);
 		setFfmpegInstall(false);
 		setOpencvInstall(false);
 		setCorsOrigins("");
@@ -113,6 +115,7 @@ function CreateFunctionModal({
 				namespaceId,
 				startup_file: isDotnetRuntime ? "" : startupFile,
 				docker_mount: dockerMount,
+				network_restricted: networkRestricted,
 				ffmpeg_install: ffmpegInstall,
 				opencv_install: opencvInstall,
 				executionAlias: executionAlias.trim() === "" ? undefined : executionAlias,
@@ -424,6 +427,51 @@ function CreateFunctionModal({
 								</label>
 							</div>
 						</div>
+					</div>
+
+					<div
+						className={`bg-gray-800/30 border border-cyan-600/50 rounded-lg p-4 ${
+							isHtmlFunction ? "opacity-50 pointer-events-none" : ""
+						}`}
+					>
+						<div className="flex items-center justify-between">
+							<div className="flex items-center gap-3">
+								<span className="text-lg">🔒</span>
+								<div>
+									<p className="text-cyan-300 font-medium text-sm">
+										Restrict Network
+									</p>
+									<p className="text-cyan-400 text-xs">
+										Run the container with Docker network disabled
+									</p>
+								</div>
+							</div>
+							<div className="relative">
+								<input
+									type="checkbox"
+									checked={networkRestricted}
+									onChange={(e) => setNetworkRestricted(e.target.checked)}
+									className="sr-only peer"
+									disabled={isLoading || isHtmlFunction}
+									id="network-restricted-create"
+								/>
+								<label
+									htmlFor="network-restricted-create"
+									className="w-12 h-6 bg-gray-600 rounded-full peer-checked:bg-gradient-to-r peer-checked:from-cyan-500 peer-checked:to-blue-500 transition-all duration-300 cursor-pointer flex items-center relative"
+								>
+									<div
+										className={`absolute w-5 h-5 bg-white rounded-full shadow-md transition-transform duration-300 ${
+											networkRestricted ? "translate-x-6" : "translate-x-0.5"
+										}`}
+									></div>
+								</label>
+							</div>
+						</div>
+						{isHtmlFunction && (
+							<p className="text-xs text-cyan-400 mt-1">
+								Network restrictions are disabled for HTML startup files
+							</p>
+						)}
 					</div>
 
 					{/* Docker Mount Toggle */}

--- a/UI/src/components/modals/functions/ImportFunctionModal.tsx
+++ b/UI/src/components/modals/functions/ImportFunctionModal.tsx
@@ -14,6 +14,7 @@ export interface SHSFExport {
 	image: string;
 	startup_file: string;
 	docker_mount: boolean;
+	network_restricted?: boolean;
 	ffmpeg_install: boolean;
 	settings: {
 		max_ram?: number;
@@ -156,6 +157,7 @@ function ImportFunctionModal({
 				image: parsed.image as any,
 				startup_file: parsed.startup_file,
 				docker_mount: parsed.docker_mount ?? false,
+				network_restricted: parsed.network_restricted ?? false,
 				ffmpeg_install: parsed.ffmpeg_install ?? false,
 				settings: parsed.settings,
 				namespaceId: selectedNamespaceId,

--- a/UI/src/components/modals/functions/UpdateFunctionModal.tsx
+++ b/UI/src/components/modals/functions/UpdateFunctionModal.tsx
@@ -683,6 +683,51 @@ function UpdateFunctionModal({
 							)}
 						</div>
 
+						<div
+							className={`bg-gray-800/30 border border-cyan-600/50 rounded-lg p-4 ${
+								isHtmlFunction ? "opacity-50 pointer-events-none" : ""
+							}`}
+						>
+							<div className="flex items-center justify-between">
+								<div className="flex items-center gap-3">
+									<span className="text-lg">🔒</span>
+									<div>
+										<p className="text-cyan-300 font-medium text-sm">
+											Restrict Network
+										</p>
+										<p className="text-cyan-400 text-xs">
+											Run the container with Docker network disabled
+										</p>
+									</div>
+								</div>
+								<div className="relative">
+									<input
+										type="checkbox"
+										checked={networkRestricted}
+										onChange={(e) => setNetworkRestricted(e.target.checked)}
+										className="sr-only peer"
+										disabled={isLoading || isHtmlFunction}
+										id="network-restricted-update"
+									/>
+									<label
+										htmlFor="network-restricted-update"
+										className="w-12 h-6 bg-gray-600 rounded-full peer-checked:bg-gradient-to-r peer-checked:from-cyan-500 peer-checked:to-blue-500 transition-all duration-300 cursor-pointer flex items-center relative"
+									>
+										<div
+											className={`absolute w-5 h-5 bg-white rounded-full shadow-md transition-transform duration-300 ${
+												networkRestricted ? "translate-x-6" : "translate-x-0.5"
+											}`}
+										></div>
+									</label>
+								</div>
+							</div>
+							{isHtmlFunction && (
+								<p className="text-xs text-cyan-400 mt-1">
+									Network restrictions are disabled for HTML startup files
+								</p>
+							)}
+						</div>
+
 						{/* FFmpeg Install Toggle */}
 						<div
 							className={`bg-gray-800/30 border border-purple-600/50 rounded-lg p-4 ${

--- a/UI/src/components/modals/functions/UpdateFunctionModal.tsx
+++ b/UI/src/components/modals/functions/UpdateFunctionModal.tsx
@@ -48,6 +48,7 @@ function UpdateFunctionModal({
 	const [error, setError] = useState("");
 	const [secureHeader, setSecureHeader] = useState<string | undefined>();
 	const [dockerMount, setDockerMount] = useState<boolean>(false);
+	const [networkRestricted, setNetworkRestricted] = useState<boolean>(false);
 	const [ffmpegInstall, setFfmpegInstall] = useState<boolean>(false);
 	const [opencv_install, setOpencvInstall] = useState<boolean>(false);
 	const [corsOrigins, setCorsOrigins] = useState<string>("");
@@ -118,6 +119,7 @@ function UpdateFunctionModal({
 			setStartupFile(functionData.startup_file || "");
 			setSecureHeader(functionData.secure_header || undefined);
 			setDockerMount(functionData.docker_mount ?? false);
+			setNetworkRestricted(functionData.network_restricted ?? false);
 			setFfmpegInstall(functionData.ffmpeg_install ?? false);
 			setOpencvInstall(functionData.opencv_install ?? false);
 			setCorsOrigins(functionData.cors_origins || "");
@@ -197,6 +199,7 @@ function UpdateFunctionModal({
 				image,
 				startup_file: isDotnetRuntime ? "" : startupFile?.trim() || undefined,
 				docker_mount: dockerMount,
+				network_restricted: networkRestricted,
 				ffmpeg_install: ffmpegInstall,
 				opencv_install: opencv_install,
 				executionAlias: executionAlias.trim() === "" ? undefined : executionAlias,
@@ -369,11 +372,17 @@ function UpdateFunctionModal({
 							<br />
 							Back up any important data before updating fields that trigger a redeploy
 							like{" "}
-							{["Image", "Docker Mount", "FFMPEG Install", "OpenCV Install"].map(
+							{[
+								"Image",
+								"Docker Mount",
+								"Network Restriction",
+								"FFMPEG Install",
+								"OpenCV Install",
+							].map(
 								(field, index) => (
 									<React.Fragment key={field}>
 										<InlineCode color="yellow">{field}</InlineCode>
-										{index < 3 && ", "}
+										{index < 4 && ", "}
 									</React.Fragment>
 								),
 							)}

--- a/UI/src/pages/functions/FunctionDetail.tsx
+++ b/UI/src/pages/functions/FunctionDetail.tsx
@@ -1151,6 +1151,7 @@ function FunctionDetail() {
 			image: functionData.image,
 			startup_file: functionData.startup_file!,
 			docker_mount: functionData.docker_mount,
+			network_restricted: functionData.network_restricted,
 			ffmpeg_install: functionData.ffmpeg_install,
 			settings: {
 				max_ram: functionData.max_ram,

--- a/UI/src/services/backend.functions.ts
+++ b/UI/src/services/backend.functions.ts
@@ -68,6 +68,7 @@ async function createFunction(config: {
 	image: Image;
 	startup_file?: string;
 	docker_mount?: boolean;
+	network_restricted?: boolean;
 	ffmpeg_install?: boolean;
 	opencv_install?: boolean;
 	settings?: {
@@ -166,6 +167,7 @@ async function updateFunction(
 		image?: Image;
 		startup_file?: string;
 		docker_mount?: boolean;
+		network_restricted?: boolean;
 		ffmpeg_install?: boolean;
 		opencv_install?: boolean;
 		namespaceId?: number;

--- a/UI/src/types/Prisma.ts
+++ b/UI/src/types/Prisma.ts
@@ -33,6 +33,7 @@ interface XFunction {
 	tags?: string; // comma-separated tags
 	startup_file: string;
 	docker_mount: boolean;
+	network_restricted: boolean;
 	ffmpeg_install: boolean;
 	imported: boolean;
 


### PR DESCRIPTION
## Summary
- add persisted `network_restricted` flag on functions (default false)
- support create/update API payloads and UI controls for network restriction
- force container recreation when the flag changes so new mode applies on next run
- set Docker `HostConfig.NetworkMode: "none"` when restricted
- include the new field in clone/import/export/detail flows and test helper data

## Notes
- could not run full build/tests in this fresh clone because dependencies are not installed (`node_modules` missing).
